### PR TITLE
is Ack argument updated in retransmission logic

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -37,7 +37,7 @@ class Config:
         self.SIMTIME = 30 * self.ONE_MIN_INTERVAL  # duration of one simulation in ms
         self.INTERFERENCE_LEVEL = 0.05  # chance that at a given moment there is already a LoRa packet being sent on your channel, outside of the Meshtastic traffic. Given in a ratio from 0 to 1.
         self.COLLISION_DUE_TO_INTERFERENCE = False
-        self.DMs = False  # Set True for sending DMs (with random destination), False for broadcasts
+        self.DMs = True  # Set True for sending DMs (with random destination), False for broadcasts
         # from RadioInterface.cpp RegionInfo regions[]
         self.regions = {
             "US": {"freq_start": 902e6, "freq_end": 928e6, "power_limit": 30},

--- a/lib/node.py
+++ b/lib/node.py
@@ -327,7 +327,7 @@ class MeshNode:
                     if self.conf.SELECTED_ROUTER_TYPE == self.conf.ROUTER_TYPE.MANAGED_FLOOD:
                         if not self.isClientMute:
                             self.verboseprint('At time', round(self.env.now, 3), 'node', self.nodeid, 'rebroadcasts received packet', p.seq)
-                            pNew = MeshPacket(self.conf, self.nodes, p.origTxNodeId, p.destId, self.nodeid, p.packetLen, p.seq, p.genTime, p.wantAck, False, None, self.env.now, self.verboseprint)
+                            pNew = MeshPacket(self.conf, self.nodes, p.origTxNodeId, p.destId, self.nodeid, p.packetLen, p.seq, p.genTime, p.wantAck, p.isAck, None, self.env.now, self.verboseprint)
                             pNew.hopLimit = p.hopLimit - 1
                             self.packets.append(pNew)
                             self.env.process(self.transmit(pNew))


### PR DESCRIPTION
<img width="1582" height="274" alt="image" src="https://github.com/user-attachments/assets/834e12e1-069f-49df-a802-52c14b3db999" />
The existing issue was that the DMs were not acknowledged. The issue was with the retransmission logic. It has hard-coded False to the isACK variable, but it should be the isACK of the received packet. 